### PR TITLE
Add missing dependency version

### DIFF
--- a/basic-c-compile.el
+++ b/basic-c-compile.el
@@ -26,7 +26,7 @@
 ;; Version: 1.1.1
 ;; Keywords: C, Makefile, compilation
 ;; URL: https://github.com/nick96/basic-c-compile
-;; Package-Requires: ((cl-lib))
+;; Package-Requires: ((cl-lib "0.5"))
 
 ;;; Commentary:
 


### PR DESCRIPTION
The version string is mandatory for compatibility with older versions of `package.el`.
