### PR TITLE
Do not require test-helper

### DIFF
--- a/test/basic-c-compile-test.el
+++ b/test/basic-c-compile-test.el
@@ -9,7 +9,6 @@
 ;;; Code:
 
 
-(require 'test-helper)
 (require 's)
 (require 'ert)
 (require 'basic-c-compile)

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -36,6 +36,4 @@
 			    ,@body)
        (f-delete default-directory :force))))
 
-
-; (provide 'test-helper)
 ;;; test-helper.el ends here


### PR DESCRIPTION
Do not require `test-helper`.  That feature
isn't (and should not be) provided.

Also see https://github.com/rejeep/ert-runner.el/issues/38.